### PR TITLE
Fix - ensure text is malloc'd to include the extra byte.

### DIFF
--- a/ext/multi_string_replace/ahocorasick.c
+++ b/ext/multi_string_replace/ahocorasick.c
@@ -42,7 +42,7 @@ int aho_add_match_text(struct ahocorasick * restrict aho, const char* text, unsi
     if (!a_text)
         goto lack_free_mem;
 
-    a_text->text = (char*) malloc(sizeof(char)*len);
+    a_text->text = (char*) malloc(sizeof(char)*(len + 1));
 
     if (!a_text->text)
         goto lack_free_mem;


### PR DESCRIPTION
Since updating to 1.0.6 we're seeing a:

```
malloc(): invalid next size (unsorted)
Aborted (core dumped)
```

My C is very weak, but to my eye https://github.com/jedld/multi_string_replace/commit/a29df64bd1aaca3a7f720b170513ffd1d51ac22f#diff-3108d9863bdd269e13e047bc25a554d76e847aa62a6eb8b26ffd70daa7f422abR52 means that the malloc needs to be made one byte larger?

You may have a better solution :-D But wanted to include something as we did a bit of spelunking and when we ran into this issue :-)

(As a random note, we see the error pretty consistently, but only in k8s pods, which feels curious - but just in case you can't reproduce, that would fit with our experience as we don't reproduce it outside k8s)