### PR TITLE
Prevent segfault with some binary characters.

### DIFF
--- a/ext/multi_string_replace/aho_trie.c
+++ b/ext/multi_string_replace/aho_trie.c
@@ -29,7 +29,7 @@ bool aho_add_trie_node(struct aho_trie * restrict t, struct aho_text_t * restric
 
     for (int text_idx = 0; text_idx < text->len; text_idx++)
     {
-        unsigned int node_text = text->text[text_idx];
+        unsigned char node_text = text->text[text_idx];
         bool find_node = false;
         int child_idx = 0;
 

--- a/spec/multi_string_replace_spec.rb
+++ b/spec/multi_string_replace_spec.rb
@@ -125,4 +125,10 @@ RSpec.describe MultiStringReplace do
       expect(mreplace_value).to eq(gsub_value)
     end
   end
+
+  context "non-ascii characters" do
+    it "shouldn't crash on binary characters" do
+      expect(MultiStringReplace.replace("", {"\xE9" => ""})).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
e.g. "\xE9".

Fixes:

```
multi_string_replace/spec/multi_string_replace_spec.rb:131: [BUG] Segmentation fault at 0x0000000000000000
ruby 3.0.6p216 (2023-03-30 revision 23a532679b) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0031 p:---- s:0157 e:000156 CFUNC  :replace
c:0030 p:0021 s:0151 e:000149 BLOCK  /mnt/limepoint/multi_string_replace/spec/multi_string_replace_spec.rb:131 [FINISH]
c:0029 p:---- s:0147 e:000146 CFUNC  :instance_exec
...
```

Fixes: #9 